### PR TITLE
 Jinhap / 2월3주차 / 9문제

### DIFF
--- a/jinhap/15649.java
+++ b/jinhap/15649.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int N, M;
+	static boolean[] isVisit;
+	static int[] arr;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		isVisit = new boolean[N + 1];
+		arr = new int[M];
+		solve(0);
+	}
+
+	public static void solve(int cnt) {
+		if (cnt == M) {
+			for (int val : arr) {
+				System.out.print(val + " ");
+			}
+			System.out.println();
+			return;
+		}
+		for (int i = 1; i <= N; i++) {
+			if (!isVisit[i]) {
+				isVisit[i] = true;
+				arr[cnt] = i;
+				solve(cnt + 1);
+				isVisit[i] = false;
+
+			}
+		}
+
+	}
+
+}

--- a/jinhap/15650.java
+++ b/jinhap/15650.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int N, M;
+	static boolean[] isVisit;
+	static int[] arr;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		isVisit = new boolean[N + 1];
+		arr = new int[M];
+		solve(0,1);
+	}
+
+	public static void solve(int cnt,int start) {
+		if (cnt == M) {
+			for (int val : arr) {
+				System.out.print(val + " ");
+			}
+			System.out.println();
+			return;
+		}
+		for (int i = start; i <= N; i++) {
+			if (!isVisit[i]) {
+				isVisit[i] = true;
+				arr[cnt] = i;
+				solve(cnt + 1,i+1);
+				isVisit[i] = false;
+
+			}
+		}
+
+	}
+
+}

--- a/jinhap/15651.java
+++ b/jinhap/15651.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main{
+	static int N, M;
+	static int[] arr;
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		arr = new int[M];
+		solve(0);
+		System.out.println(sb);
+	}
+
+	public static void solve(int cnt ) {
+		if (cnt == M) {
+			for (int val : arr) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		for (int i = 1; i <= N; i++) {
+			arr[cnt] = i;
+			solve(cnt + 1);
+		}
+	}
+
+}

--- a/jinhap/15652.java
+++ b/jinhap/15652.java
@@ -1,0 +1,34 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int N, M;
+	static int[] arr;
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		arr = new int[M];
+		solve(0, 1);
+		System.out.println(sb);
+	}
+
+	public static void solve(int cnt, int start) {
+		if (cnt == M) {
+			for (int val : arr) {
+				sb.append(val).append(" ");
+			}
+			sb.append("\n");
+			return;
+		}
+		for (int i = start; i <= N; i++) {
+			arr[cnt] = i;
+			solve(cnt + 1, i);
+		}
+	}
+}

--- a/jinhap/1629.java
+++ b/jinhap/1629.java
@@ -1,0 +1,28 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Scanner;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		long a = Integer.parseInt(st.nextToken());
+		long b = Integer.parseInt(st.nextToken());
+		long c = Integer.parseInt(st.nextToken());
+		long answer = solve(a, b, c);
+		System.out.println(answer);
+
+	}
+
+	public static long solve(long a, long b, long c) {
+		if (b == 1)
+			return a % c;
+		long tmp=solve(a, b / 2, c);
+		if (b % 2 == 0)
+			return tmp*tmp % c;
+		else
+			return (tmp*tmp % c) * a % c;
+	}
+}

--- a/jinhap/1697.java
+++ b/jinhap/1697.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main_1697 {
+	public static int N, X;
+	public static int[] isVisit;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		X = Integer.parseInt(st.nextToken());
+		isVisit = new int[100001];
+		bfs(N);
+	}
+
+	public static void bfs(int curPoint) {
+		Queue<Integer> q = new LinkedList<Integer>();
+		q.offer(curPoint);
+		isVisit[curPoint] = 1;
+		while (!q.isEmpty()) {
+			int nextPoint = q.poll();
+			if (nextPoint == X) {
+				System.out.println(isVisit[nextPoint]-1);
+				return;
+			}
+			if (nextPoint * 2 <= 100000 && isVisit[nextPoint * 2] == 0) {
+				isVisit[nextPoint * 2] = isVisit[nextPoint] + 1;
+				q.offer(nextPoint * 2);
+			}
+			if (nextPoint + 1 <= 100000 && isVisit[nextPoint + 1] == 0) {
+				isVisit[nextPoint + 1] = isVisit[nextPoint] + 1;
+				q.offer(nextPoint + 1);
+			}
+			if (nextPoint - 1 >= 0 && isVisit[nextPoint - 1] == 0) {
+				isVisit[nextPoint - 1] = isVisit[nextPoint] + 1;
+				q.offer(nextPoint - 1);
+			}
+		}
+	}
+}

--- a/jinhap/1992.java
+++ b/jinhap/1992.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+	static int N;
+	static int[][] arr;
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		arr = new int[N][N];
+		for (int i = 0; i < N; i++) {
+			char[] c = br.readLine().toCharArray();
+			for (int j = 0; j < N; j++) {
+				arr[i][j] = c[j] - '0';
+			}
+		}
+		solve(N, 0, 0);
+		System.out.println(sb);
+	}
+
+	public static void solve(int n, int x, int y) {
+
+		if (isPossible(n,x, y)) {
+			sb.append(arr[x][y]);
+			return;
+		}
+
+		int newSize = n / 2;
+
+		sb.append('(');
+
+		solve(newSize,x, y);
+		solve(newSize,x, y + newSize);
+		solve(newSize,x + newSize, y);
+		solve(newSize,x + newSize, y + newSize);
+
+		sb.append(')');
+
+	}
+
+	public static boolean isPossible(int n, int x, int y) {
+		int value = arr[x][y];
+
+		for (int i = x; i < x + n; i++) {
+			for (int j = y; j < y + n; j++) {
+				if (value != arr[i][j]) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+}

--- a/jinhap/2580.java
+++ b/jinhap/2580.java
@@ -1,0 +1,85 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+class Point {
+	int x;
+	int y;
+	int val;
+
+	Point(int x, int y) {
+		this.x = x;
+		this.y = y;
+		this.val = 0;
+	}
+}
+
+public class Main {
+	public static final int N = 9;
+	public static int[][] map = new int[N][N];
+	public static List<Point> list = new ArrayList<Point>();
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				if (map[i][j] == 0)
+					list.add(new Point(i, j));
+			}
+		}
+		solve(0);
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				sb.append(map[i][j]).append(" ");
+			}
+			sb.append("\n");
+		}
+		sb.setLength(sb.length() - 1);
+		sb.setLength(sb.length() - 1);
+		System.out.println(sb);
+	}
+
+	public static boolean solve(int idx) {
+		if (idx == list.size()) {
+			return true;
+		}
+		Point p = list.get(idx);
+		for (int val = 1; val <= 9; val++) {
+			if (check(p.x, p.y, val)) {
+				map[p.x][p.y] = val;
+				if (solve(idx + 1))
+					return true;
+				map[p.x][p.y] =0;
+
+			}
+		}
+
+		return false;
+	}
+
+	public static boolean check(int x, int y, int val) {
+		for (int i = 0; i < N; i++) {
+			if (i != x && map[i][y] == val)
+				return false;
+			if (i != y && map[x][i] == val)
+				return false;
+		}
+		int startX = x - x % 3;
+		int startY = y - y % 3;
+		for (int i = startX; i < startX + 3; i++) {
+			for (int j = startY; j < startY + 3; j++) {
+				if(i==x&&j==y) continue;
+				if ( map[i][j] == val)
+					return false;
+			}
+		}
+		return true;
+	}
+}

--- a/jinhap/3109.java
+++ b/jinhap/3109.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main{
+	static int R, C, ans;
+	static char map[][];
+	static boolean isVisit[][];
+	static int[] dx = { -1, 0, 1 };
+	static int[] dy = { 1, 1, 1 };
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		R = Integer.parseInt(st.nextToken());
+		C = Integer.parseInt(st.nextToken());
+		map = new char[R][C];
+		isVisit = new boolean[R][C];
+		for (int i = 0; i < R; i++) {
+			st = new StringTokenizer(br.readLine());
+			map[i] = st.nextToken().toCharArray();
+		}
+		ans = 0;
+		for (int i = 0; i < R; i++) {
+			solve(i, 0);
+		}
+		System.out.println(ans);
+	}
+
+	public static boolean solve(int row, int col) {
+		map[row][col] = 'X';
+		if (col == C - 1) {
+			ans++;
+			return true;
+		}
+		for (int i = 0; i < 3; i++) {
+			int nx = row + dx[i];
+			int ny = col + dy[i];
+			if (nx >= 0 && nx < R && ny >= 0 && ny < C && map[nx][ny] == '.') {
+				if (solve(nx, ny))
+					return true;
+			}
+		}
+		return false;
+
+	}
+}


### PR DESCRIPTION
1697 숨바꼭질
bfs문제
큐에 배열로 카운트를 따로 넣어줬었는데 메모리초과로 통과못했다.
isVisit을 원래 boolean으로 방문했는지 확인하는 용도로만 사용했는데
그거보단 int형으로 하고 이전 큐에 들어있던값 +1해서 카운트하는용도로 같이 쓰니까 메모리절약이 된다.

1629 곱셈
잘 생각해놓고
자료형을 int로 써서 계속 실패하고 해맸다.
tmp*tmp에서 int를 초과하면 잘못되는것같다.

3109
앞에서 어떤경로로 왔든 현재 점에서 갈수 있는 경우는 다 같다.(도착하던가 못하던가)
우상 , 우 , 우하 순서로 dfs(열 우선)로 돌다가 한번이라도 도착했으면 그만탐색한다.
이걸 모든 행 첫열에서 수행하면 갯수 나온다.

15649~15652
일반 순열은 방문했는지 저장하면서 dfs순회
중복 순열은 방문했는지 확인할 필요없음
조합의 경우 상위 레벨에서 방문한 노드 이후부터 dfs순회한다
system.out함수가 시간이 많이 걸리는듯하다 stringbuilder에 쌓아놓고 한번 출력해서 시간통과

2580
거의 다 잘하고 59번라인 때문에 막혔었다. 필요 없다고 생각했는데 넣으니까 된다.
solve를 파고들어가면서 계속 map을 건드리면서 꼬이는걸 방지하는 느낌인데 정확히 정리가 안된다.
저기가 실행된다면 현재내가 넣어준 val로는 스도쿠를 완성할수 없다는 뜻인데
그걸 확인하면서 map에 val을 넣어줬기때문에 다시 0으로 돌려놔야한다. 위에서 check를 제대로 할 수 없다 